### PR TITLE
added sleep module to test PR

### DIFF
--- a/sleep/sleep.docu.xml
+++ b/sleep/sleep.docu.xml
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<documentation xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="documentation.xsd">
+  <!-- mandatory fields: author, category, updated, description -->
+  <info>
+    <!-- forename lastname -->
+    <author>Michael Kluge</author>
+    <!-- day the module was updated the last time -->
+    <updated>2019-03-13</updated>
+    <category>General</category>
+    <description maxVersion="1" minVersion="1">pauses for a specified amount of time</description>
+    <!-- ##### optional ##### -->
+    <!-- website of the dependencies used in this module -->
+    <website>https://www.gnu.org/software/coreutils/sleep</website>
+    <!-- external dependencies required for that module -->
+    <dependencies maxVersion="1" minVersion="1">GNU sleep</dependencies>
+  </info>
+  <!-- ##### optional ##### -->
+  <!-- github usernames of users who should be able to commit changes to that module -->
+  <maintainer>
+    <username>klugem</username>
+  </maintainer>
+  <parameter>
+    <!-- mandatory fields per parameter: name, type, description -->
+    <!-- optional fields per parameter: restrictions, default, minOccurs, maxOccurs, minVersion, maxVersion -->
+    <param maxOccurs="1" minOccurs="1" name="wait" type="string" restrictions="[0-9]+[smhd]{0,1}">
+      <description>non-negative number followed by an optional unit; the default is seconds; valid units: seconds (s), minutes(m), hours (h), days (d)</description>
+    </param>
+  </parameter>
+</documentation>

--- a/sleep/sleep.xsd
+++ b/sleep/sleep.xsd
@@ -1,0 +1,47 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<x:schema xmlns:x="http://www.w3.org/2001/XMLSchema" xmlns:vc="http://www.w3.org/2007/XMLSchema-versioning" vc:minVersion="1.1" xmlns:xerces="http://xerces.apache.org">
+
+	<!-- definition of the task parameters -->
+	<x:complexType name="sleepTaskParameterType">
+		<x:all>
+			<x:element name="wait" type="paramWait_sleep" minOccurs="1" maxOccurs="1" />
+		</x:all>
+	</x:complexType>
+
+	<!-- change default attributes -->
+	<x:complexType name="sleepTaskOverrideType">
+		<x:complexContent>
+			<x:restriction base="baseAttributeTaskType">
+				<x:attribute name="binName" type="x:string" fixed="sleep" />
+				<x:attribute name="isWatchdogModule" type="x:boolean" default="false" />
+				<x:attribute ref="paramFormat" fixed="plain" />
+				<x:attribute ref="quoteFormat" fixed="unquoted" />
+			</x:restriction>
+		</x:complexContent>
+	</x:complexType>
+
+	<!-- definition of final task -->
+	<x:complexType name="sleepTaskType">
+		<x:complexContent>
+			<x:extension base="sleepTaskOverrideType">
+				<x:all>
+					<x:element name="parameter" type="sleepTaskParameterType" minOccurs="1" maxOccurs="1" />
+					<x:group ref="defaultTaskElements" />
+				</x:all>
+			</x:extension>
+		</x:complexContent>
+	</x:complexType>
+
+	<!-- make task definition availible via substitution group -->
+	<x:element name="sleepTask" type="sleepTaskType" substitutionGroup="abstractTask" />
+
+	<!-- module specific parameter types -->
+	<x:complexType name="paramWait_sleep">
+		<x:simpleContent>
+			<x:restriction base="paramString">
+				<x:assertion test="matches($value, '(\$\{[A-Za-z_][A-Za-z_0-9]*\})|(\$\(.+\))|([\[\(\{](\$[A-Za-z_]+(,\s*){0,1}){0,1}([0-9]+(,\S*){0,1}){0,1}[\]\)\}])') or matches($value, '^[0-9]+[smhd]{0,1}$')" xerces:message="Parameter with name '{$tag}' must match [0-9]+[smhd]{0,1}." />
+			</x:restriction>
+		</x:simpleContent>
+	</x:complexType>
+
+</x:schema>


### PR DESCRIPTION
### Folder structure

Modules must contain at least an XSD module definition file (*moduleName.xsd*) and an XML documentation file (*moduleName.docu.xml*).
If test data is included, it should be stored in a folder named *test_data*.

Example:

    moduleName
    ├── moduleName.xsd
    ├── moduleName.docu.xml
    ├── moduleName.sh
    └── test_data
        ├── testFile1.txt
        └── testFile2.txt
   
### Automatic Travis CI tests triggered by pull requests

Before a pull request can be merged with the master branch some Travis CI tests must succeed.
Currently the following tests are implemented:

- signed commit test: 
  - only [signed commits](https://help.github.com/en/articles/signing-commits) can be merged 
- write permission test:
  - the github username of the creator of the pull request must be included in the XML documentation file (*\<maintainer\>* tag)
- separate module test: 
  - all files affected by the pull request must be part of one module
- XSD validation test: 
  - XSD module definition file must be parseable by Watchdog
- XML documentation test:   
  - XML documentation file must follow its [XSD schema](https://github.com/watchdog-wms/watchdog-wms/blob/master/xsd/documentation.xsd)
  - parameter and return values must fit 
- virus scanner test: 
  - all files part of the pull request must pass the virus scan
