### PR TITLE
Update templates

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,33 +1,11 @@
-### Folder structure
+### Checks
+- [ ] I have read the [CONTRIBUTING](CONTRIBUTING.md) document.
 
-Modules must contain at least an XSD module definition file (*moduleName.xsd*) and an XML documentation file (*moduleName.docu.xml*).
-If test data is included, it should be stored in a folder named *test_data*.
+### Types of changes
+- [ ] new module (initial commit of a new module)
+- [ ] new feature (non-breaking change which adds functionality)
+- [ ] bug fix (non-breaking change which fixes an issue)
+- [ ] breaking change (fix or feature that would cause existing functionality to change)
 
-Example:
-
-    moduleName
-    ├── moduleName.xsd
-    ├── moduleName.docu.xml
-    ├── moduleName.sh
-    └── test_data
-        ├── testFile1.txt
-        └── testFile2.txt
-   
-### Automatic Travis CI tests triggered by pull requests
-
-Before a pull request can be merged with the master branch some Travis CI tests must succeed.
-Currently the following tests are implemented:
-
-- signed commit test: 
-  - only [signed commits](https://help.github.com/en/articles/signing-commits) can be merged 
-- write permission test:
-  - the github username of the creator of the pull request must be included in the XML documentation file (*\<maintainer\>* tag)
-- separate module test: 
-  - all files affected by the pull request must be part of one module
-- XSD validation test: 
-  - XSD module definition file must be parseable by Watchdog
-- XML documentation test:   
-  - XML documentation file must follow its [XSD schema](https://github.com/watchdog-wms/watchdog-wms/blob/master/xsd/documentation.xsd)
-  - parameter and return values must fit 
-- virus scanner test: 
-  - all files part of the pull request must pass the virus scan
+### Description
+Please add here a short description of the proposed changes.

--- a/.issue_template
+++ b/.issue_template
@@ -1,0 +1,33 @@
+### Affected module: [replace with module]
+
+####  I'm submitting a ...
+
+* [ ] bug report
+* [ ] feature request
+
+#### Prerequisites for bug reports
+
+* [ ] Can you reproduce the problem ?
+* [ ] Are you running the latest version ?
+
+#### Description
+
+[Description of the bug or feature]
+
+*Expected behavior:* [What you expected to happen]
+
+*Actual behavior:* [What actually happened]
+
+#### Steps to reproduce
+
+1. [First Step]
+2. [Second Step]
+3. [and so on...]
+
+
+
+#### Used versions
+
+* OS: 
+* Java: 
+* Watchdog: 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,33 @@
+### Folder structure
+
+Modules must contain at least an XSD module definition file (*moduleName.xsd*) and an XML documentation file (*moduleName.docu.xml*).
+If test data is included, it should be stored in a folder named *test_data*.
+
+Example:
+
+    moduleName
+    ├── moduleName.xsd
+    ├── moduleName.docu.xml
+    ├── moduleName.sh
+    └── test_data
+        ├── testFile1.txt
+        └── testFile2.txt
+   
+### Automatic Travis CI tests triggered by pull requests
+
+Before a pull request can be merged with the master branch some Travis CI tests must succeed.
+Currently the following tests are implemented:
+
+- signed commit test: 
+  - only [signed commits](https://help.github.com/en/articles/signing-commits) can be merged 
+- write permission test:
+  - the github username of the creator of the pull request must be included in the XML documentation file (*\<maintainer\>* tag)
+- separate module test: 
+  - all files affected by the pull request must be part of one module
+- XSD validation test: 
+  - XSD module definition file must be parseable by Watchdog
+- XML documentation test:   
+  - XML documentation file must follow its [XSD schema](https://github.com/watchdog-wms/watchdog-wms/blob/master/xsd/documentation.xsd)
+  - parameter and return values must fit 
+- virus scanner test: 
+  - all files part of the pull request must pass the virus scan


### PR DESCRIPTION
### Folder structure

Modules must contain at least an XSD module definition file (*moduleName.xsd*) and an XML documentation file (*moduleName.docu.xml*).
If test data is included, it should be stored in a folder named *test_data*.

Example:

    moduleName
    ├── moduleName.xsd
    ├── moduleName.docu.xml
    ├── moduleName.sh
    └── test_data
        ├── testFile1.txt
        └── testFile2.txt
   
### Automatic Travis CI tests triggered by pull requests

Before a pull request can be merged with the master branch some Travis CI tests must succeed.
Currently the following tests are implemented:

- signed commit test: 
  - only [signed commits](https://help.github.com/en/articles/signing-commits) can be merged 
- write permission test:
  - the github username of the creator of the pull request must be included in the XML documentation file (*\<maintainer\>* tag)
- separate module test: 
  - all files affected by the pull request must be part of one module
- XSD validation test: 
  - XSD module definition file must be parseable by Watchdog
- XML documentation test:   
  - XML documentation file must follow its [XSD schema](https://github.com/watchdog-wms/watchdog-wms/blob/master/xsd/documentation.xsd)
  - parameter and return values must fit 
- virus scanner test: 
  - all files part of the pull request must pass the virus scan
